### PR TITLE
build: update Dockerfile to use Go version 1.20

### DIFF
--- a/Dockerfile.06
+++ b/Dockerfile.06
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG GO_VERSION=1.21
+ARG GO_VERSION=1.20
 FROM golang:${GO_VERSION}-alpine as builder
 
 WORKDIR /src


### PR DESCRIPTION
- Update the value of the `GO_VERSION` argument in the Dockerfile from `1.21` to `1.20`